### PR TITLE
fix(block-ciphers): cbc: use array offsets

### DIFF
--- a/src/block-modes/cbc.ts
+++ b/src/block-modes/cbc.ts
@@ -45,7 +45,7 @@ export class Cbc<T extends BlockCipher> extends BlockCipherMode<T> {
   decrypt(data: Uint8Array): Uint8Array {
     this.checkBlockSize(data.length);
 
-    const view = new DataView(data.buffer);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
     const decrypted = data.slice();
     const decryptedView = new DataView(decrypted.buffer);
 

--- a/src/block-modes/cfb.ts
+++ b/src/block-modes/cfb.ts
@@ -22,7 +22,7 @@ export class Cfb<T extends BlockCipher> extends BlockCipherMode<T> {
   encrypt(data: Uint8Array): Uint8Array {
     data = pad(data, this.padding, this.blockSize);
 
-    const view = new DataView(data.buffer);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
     const encrypted = new Uint8Array(data.length);
     const encryptedView = new DataView(encrypted.buffer);
 


### PR DESCRIPTION
For example, if decrypting a Uint8Array created with an offset, decrypt() would skip that offset and read the entire underlying buffer, even if not all data is encrypted.


I'm unsure whether this means a breaking change.